### PR TITLE
fix some

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.idea
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/demo/run_inference.md
+++ b/demo/run_inference.md
@@ -23,7 +23,7 @@
 
 3. 利用原始LLaMA文件中的`7B/consolidated.00.pth`文件，运行以下bash命令，使用`decrypt.py`对Lawyer LLaMA模型文件进行解码。
 ```bash
-for f in "/path/to/model/pytorch_model"*; \
+for f in "/path/to/model/pytorch_model"*".enc"; \
     do if [ -f "$f" ]; then \
        python3 decrypt.py "$f" "/path/to_original_llama/7B/consolidated.00.pth" "/path/to/model"; \
     fi; \


### PR DESCRIPTION
- 在.gitignore中忽略pytorch生成的.idea目录；
- 通过huggingface-hub下载的模型文件中有一个名为pytorch_model.bin.index.json的文件不需要decrypt，使用.enc后辍过滤此文件。